### PR TITLE
Pretty-print Cloudformation JSON Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ This is my first real python project, so I'm sure the code can be, just generall
 Known issues:
 
 * Templates are passed in as a JSON string to CF, this will break large templates
-* Cumulus generated stacks display as one liners in the CF console
 
 Roadmap:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ News
 
    ```
    highlight-output: true
-   ``` 
+   ```
 
 ### 2014-04-17
 + You can now insert PyStache {{}} style variables to import environment variables.

--- a/cumulus/CFStack.py
+++ b/cumulus/CFStack.py
@@ -207,7 +207,12 @@ class CFStack(object):
                                  " Error: %s", self.template_name, self.name,
                                  exception)
             exit(1)
-        self.template_body = simplejson.dumps(template)
+        self.template_body = simplejson.dumps(
+            template,
+            sort_keys=True,
+            indent=2,
+            separators=(',', ': '),
+        )
         return True
 
     def template_uptodate(self, current_cf_stacks):


### PR DESCRIPTION
This commit will format and indent the cloudformation template when it is loaded. This makes the template more readable in the AWS console.