### PR TITLE
Add ability to limit which AWS account a stack can be run against

### DIFF
--- a/cumulus/MegaStack.py
+++ b/cumulus/MegaStack.py
@@ -10,7 +10,7 @@ import yaml
 import pystache
 import os
 from cumulus.CFStack import CFStack
-from boto import cloudformation
+from boto import cloudformation, iam
 
 
 class MegaStack(object):
@@ -45,6 +45,19 @@ class MegaStack(object):
             self.logger.critical("No region specified for mega stack,"
                                  + " don't know where to build it.")
             exit(1)
+
+        if 'account_id' in self.stackDict[self.name]:
+            # Get the account ID for the current AWS credentials
+            iamconn = iam.connect_to_region(self.region)
+            user_response = iamconn.get_user()['get_user_response']
+            user_result = user_response['get_user_result']
+            account_id = user_result['user']['arn'].split(':')[4]
+
+            # Check if the current account ID matches the stack's account ID
+            if account_id != str(self.stackDict[self.name]['account_id']):
+                self.logger.critical("Account ID of stack does not match the"
+                                     + " account ID of your AWS credentials.")
+                exit(1)
 
         self.sns_topic_arn = self.stackDict[self.name].get('sns-topic-arn', [])
         if isinstance(self.sns_topic_arn, str):

--- a/examples/cumulus_example_stack.yaml
+++ b/examples/cumulus_example_stack.yaml
@@ -8,7 +8,7 @@ example-stack:
 #   sns-topic-arn:
 #       - arn:aws:sns:region:account:topic1
 #       - arn:aws:sns:region:account:topic2
-    #The region Cumulus will create the stack in 
+    #The region Cumulus will create the stack in
     region: us-west-2
     #Turn on colour cloudformation event status output
     highlight-output: true

--- a/examples/cumulus_example_stack.yaml
+++ b/examples/cumulus_example_stack.yaml
@@ -12,6 +12,8 @@ example-stack:
     region: us-west-2
     #Turn on colour cloudformation event status output
     highlight-output: true
+    #Limit the account in which this stack can be run
+    account_id: 972549067366
     stacks:
         #Base stack, has the same name as the top level. Cumulus knows not to call it examplestack-example-stack.
         #This template has no parameters to pass in


### PR DESCRIPTION
Where I work we have separate AWS accounts for production and non-production resources. I want to add a safety net where I can specify an AWS account ID in a stack and have cumulus exit if the given account ID does not match the ID associated with the AWS credentials used to make `boto` calls. The idea being that a non-production stack can never accidentally be run against production.

This PR adds this ability and is completely optional, all existing cumulus configs will continue working as normal.