### PR TITLE
Adds some new command line arguments and global vars

### DIFF
--- a/cumulus/CFStack.py
+++ b/cumulus/CFStack.py
@@ -12,7 +12,7 @@ class CFStack(object):
     region, template and what other stacks it depends on.
     """
     def __init__(self, mega_stack_name, name, params, template_name, region,
-                 sns_topic_arn, tags=None, depends_on=None, prefix=None):
+                 sns_topic_arn, tags=None, depends_on=None, prefix=None, global_dict=None):
         self.logger = logging.getLogger(__name__)
         self.prefix = prefix
 
@@ -47,6 +47,11 @@ class CFStack(object):
             self.tags = {}
         else:
             self.tags = tags
+
+        if global_dict is None:
+            self.global_dict = {}
+        else:
+            self.global_dict = global_dict
 
         try:
             open(template_name, 'r')
@@ -125,6 +130,12 @@ class CFStack(object):
         # Static value set, so use it
         if 'value' in param_dict:
             return str(param_dict['value'])
+        # Handle global variable dereference
+        elif ('type' in param_dict and
+              param_dict['type'] == "global" and
+              'variable' in param_dict and
+              param_dict['variable'] in self.global_dict):
+            return str(self.global_dict[param_dict['variable']])
         # No static value set, but if we have a source,
         # type and variable can try getting from CF
         elif ('source' in param_dict and

--- a/cumulus/CFStack.py
+++ b/cumulus/CFStack.py
@@ -12,10 +12,14 @@ class CFStack(object):
     region, template and what other stacks it depends on.
     """
     def __init__(self, mega_stack_name, name, params, template_name, region,
-                 sns_topic_arn, tags=None, depends_on=None):
+                 sns_topic_arn, tags=None, depends_on=None, prefix=None):
         self.logger = logging.getLogger(__name__)
+        self.prefix = prefix
+
         if mega_stack_name == name:
             self.cf_stack_name = name
+        elif prefix:
+            self.cf_stack_name = "%s-%s" % (prefix, name)
         else:
             self.cf_stack_name = "%s-%s" % (mega_stack_name, name)
         self.mega_stack_name = mega_stack_name
@@ -31,6 +35,8 @@ class CFStack(object):
             for dep in depends_on:
                 if dep == mega_stack_name:
                     self.depends_on.append(dep)
+                elif prefix:
+                    self.depends_on.append("%s-%s" % (prefix, dep))
                 else:
                     self.depends_on.append("%s-%s" % (mega_stack_name, dep))
         self.region = region
@@ -126,6 +132,9 @@ class CFStack(object):
               'variable' in param_dict):
             if param_dict['source'] == self.mega_stack_name:
                 source_stack = param_dict['source']
+            elif self.prefix:
+                source_stack = ("%s-%s" %
+                                (self.prefix, param_dict['source']))
             else:
                 source_stack = ("%s-%s" %
                                 (self.mega_stack_name, param_dict['source']))

--- a/cumulus/MegaStack.py
+++ b/cumulus/MegaStack.py
@@ -18,7 +18,7 @@ class MegaStack(object):
     Main worker class for cumulus. Holds array of CFstack objects and does most
     of the calls to CloudFormation API
     """
-    def __init__(self, yamlFile, prefix=None, override_dict=None):
+    def __init__(self, yamlFile, prefix=None, override_dict=None, highlight_arg=None):
         self.logger = logging.getLogger(__name__)
         self.prefix = prefix
 
@@ -38,6 +38,10 @@ class MegaStack(object):
         # Now we know we only have one top element,
         # that must be the mega stack name
         self.name = self.stackDict.keys()[0]
+
+        # Override highlight-output with argument if present.
+        if highlight_arg is not None:
+            self.stackDict[self.name]['highlight-output'] = highlight_arg
 
         # Find and set the mega stacks region. Exit if we can't find it
         if 'region' in self.stackDict[self.name]:

--- a/cumulus/MegaStack.py
+++ b/cumulus/MegaStack.py
@@ -73,6 +73,8 @@ class MegaStack(object):
         # Array for holding CFStack objects once we create them
         self.stack_objs = []
 
+        self.global_dict = self.stackDict[self.name].get('vars', {})
+
         # Get the names of the sub stacks from the yaml file and sort in array
         self.cf_stacks = self.stackDict[self.name]['stacks'].keys()
 
@@ -124,7 +126,8 @@ class MegaStack(object):
                             sns_topic_arn=local_sns_arn,
                             depends_on=the_stack.get('depends'),
                             tags=merged_tags,
-                            prefix=self.prefix
+                            prefix=self.prefix,
+                            global_dict=self.global_dict
                         )
                     )
 

--- a/cumulus/MegaStack.py
+++ b/cumulus/MegaStack.py
@@ -18,7 +18,7 @@ class MegaStack(object):
     Main worker class for cumulus. Holds array of CFstack objects and does most
     of the calls to CloudFormation API
     """
-    def __init__(self, yamlFile, prefix=None):
+    def __init__(self, yamlFile, prefix=None, override_dict=None):
         self.logger = logging.getLogger(__name__)
         self.prefix = prefix
 
@@ -74,6 +74,10 @@ class MegaStack(object):
         self.stack_objs = []
 
         self.global_dict = self.stackDict[self.name].get('vars', {})
+        if override_dict:
+            for override in override_dict:
+                if override in self.global_dict:
+                    self.global_dict[override] = override_dict[override]
 
         # Get the names of the sub stacks from the yaml file and sort in array
         self.cf_stacks = self.stackDict[self.name]['stacks'].keys()

--- a/cumulus/MegaStack.py
+++ b/cumulus/MegaStack.py
@@ -18,8 +18,9 @@ class MegaStack(object):
     Main worker class for cumulus. Holds array of CFstack objects and does most
     of the calls to CloudFormation API
     """
-    def __init__(self, yamlFile):
+    def __init__(self, yamlFile, prefix=None):
         self.logger = logging.getLogger(__name__)
+        self.prefix = prefix
 
         # load the yaml file and turn it into a dict
         thefile = open(yamlFile, 'r')
@@ -122,7 +123,8 @@ class MegaStack(object):
                             region=self.region,
                             sns_topic_arn=local_sns_arn,
                             depends_on=the_stack.get('depends'),
-                            tags=merged_tags
+                            tags=merged_tags,
+                            prefix=self.prefix
                         )
                     )
 

--- a/cumulus/__init__.py
+++ b/cumulus/__init__.py
@@ -47,6 +47,14 @@ def main():
         "-o", "--override-global",
         action='append', dest="override_global", required=False,
         help="Override a global variable. Example: --override-global \"globalVariable=newValue\"")
+    conf_parser.add_argument(
+        "--highlight",
+        action="store_true", dest="highlight", required=False,
+        help="Highlight output. This takes precedence over highlight-output in the yaml file.")
+    conf_parser.add_argument(
+        "--no-highlight",
+        action="store_false", dest="highlight", required=False,
+        help="Don't highlight output. This takes precedence over highlight-output in the yaml file.")
     args = conf_parser.parse_args()
 
     # Validate that action is something we know what to do with
@@ -88,7 +96,7 @@ def main():
         override_dict = None
 
     # Create the mega_stack object and sort out dependencies
-    the_mega_stack = MegaStack(args.yamlfile, args.cf_prefix, override_dict)
+    the_mega_stack = MegaStack(args.yamlfile, args.cf_prefix, override_dict, args.highlight)
     the_mega_stack.sort_stacks_by_deps()
 
     # Print some info about what we found in the yaml and dependency order

--- a/cumulus/__init__.py
+++ b/cumulus/__init__.py
@@ -43,6 +43,10 @@ def main():
         "-p", "--prefix", metavar="PREFIX",
         dest="cf_prefix", required=False,
         help="The prefix of the created stacks. Default is the name of the mega stack.")
+    conf_parser.add_argument(
+        "-o", "--override-global",
+        action='append', dest="override_global", required=False,
+        help="Override a global variable. Example: --override-global \"globalVariable=newValue\"")
     args = conf_parser.parse_args()
 
     # Validate that action is something we know what to do with
@@ -74,8 +78,17 @@ def main():
         exit(1)
     logging.getLogger('boto').setLevel(boto_numeric_level)
 
+    if args.override_global:
+        try:
+            override_dict = dict(k for k in (x.split('=') for x in args.override_global))
+        except ValueError as exception:
+            print "Illegal global override parameter in: %s" % args.override_global
+            exit(1)
+    else:
+        override_dict = None
+
     # Create the mega_stack object and sort out dependencies
-    the_mega_stack = MegaStack(args.yamlfile, args.cf_prefix)
+    the_mega_stack = MegaStack(args.yamlfile, args.cf_prefix, override_dict)
     the_mega_stack.sort_stacks_by_deps()
 
     # Print some info about what we found in the yaml and dependency order

--- a/cumulus/__init__.py
+++ b/cumulus/__init__.py
@@ -35,6 +35,10 @@ def main():
         dest="stackname", required=False,
         help="The stack name, used with the watch action,"
              " ignored for other actions")
+    conf_parser.add_argument(
+        "-c", "--compact",
+        action="store_true", dest="compactbody", required=False,
+        help="Compress each template body by removing spaces.")
     args = conf_parser.parse_args()
 
     # Validate that action is something we know what to do with
@@ -80,7 +84,7 @@ def main():
 
     # Run the method of the mega stack object for the action provided
     if args.action == 'create':
-        the_mega_stack.create(args.stackname)
+        the_mega_stack.create(args.stackname, args.compactbody)
 
     if args.action == 'check':
         the_mega_stack.check(args.stackname)

--- a/cumulus/__init__.py
+++ b/cumulus/__init__.py
@@ -39,6 +39,10 @@ def main():
         "-c", "--compact",
         action="store_true", dest="compactbody", required=False,
         help="Compress each template body by removing spaces.")
+    conf_parser.add_argument(
+        "-p", "--prefix", metavar="PREFIX",
+        dest="cf_prefix", required=False,
+        help="The prefix of the created stacks. Default is the name of the mega stack.")
     args = conf_parser.parse_args()
 
     # Validate that action is something we know what to do with
@@ -71,7 +75,7 @@ def main():
     logging.getLogger('boto').setLevel(boto_numeric_level)
 
     # Create the mega_stack object and sort out dependencies
-    the_mega_stack = MegaStack(args.yamlfile)
+    the_mega_stack = MegaStack(args.yamlfile, args.cf_prefix)
     the_mega_stack.sort_stacks_by_deps()
 
     # Print some info about what we found in the yaml and dependency order

--- a/examples/legostack/legostack.yaml
+++ b/examples/legostack/legostack.yaml
@@ -7,6 +7,9 @@ legostack:
   # Working on N.California. You can change it just remember to also update availablilty zones below and AMI ids
   region: us-west-1
   highlight-output: true
+  # Add global variables
+  vars:
+    globalInstanceType: 't2.small'
   # Tags defined here are spread across every resource created by sub-stacks
   tags:
     globaltag: tagvalue
@@ -125,7 +128,8 @@ legostack:
         - dmz-sub
       params:
         ParamInstanceType:
-          value: 't2.small'
+          type: global
+          variable: globalInstanceType
         ParamUseElasticIP:
           value: 'true'
         ParamInstanceAMI:
@@ -198,7 +202,8 @@ legostack:
         - nat
       params:
         ParamInstanceType:
-          value: 't2.small'
+          type: global
+          variable: globalInstanceType
         ParamInstanceAMI:
           # Ubuntu 12.04 Precise HVM EBS
           value: 'ami-0dad4949'


### PR DESCRIPTION
Hi,

We are using cumulus to deploy stacks on different accounts. When deploying the same stack (megastack) against different accounts there are some difficulties with the current implementation, hence the following commits:
50646e7 Add global variables
9517fca Add argument for overriding global variables
a71e1f9 examples: add global var

Also, we ran in to a size problem with one of our larger stacks:
8ddfb19 Add compact body argument

To be able to deploy the stack on the same account multiple times one need another prefix:
2517ec8 Add stack prefix argument

And finally - some times we run cumulus on our desktop where highlighting is a good idea, but when deploying using e.g. Jenkins you might want to turn highlighting off for the same stack. This is what the following commit takes care of:
88aadd1 Add --[no-]highlight output argument

Hope you're interested and let me know any comments or feedback!

Thanks,
 Oskar